### PR TITLE
feat: add AWS S3 Vectors MCP server tools

### DIFF
--- a/src/s3-vectors-mcp/awslabs/__init__.py
+++ b/src/s3-vectors-mcp/awslabs/__init__.py
@@ -1,0 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""awslabs s3-vectors-mcp."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/src/s3-vectors-mcp/awslabs/s3_vectors_mcp_server/__init__.py
+++ b/src/s3-vectors-mcp/awslabs/s3_vectors_mcp_server/__init__.py
@@ -1,0 +1,17 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""AWS S3 Vectors MCP Server."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/src/s3-vectors-mcp/awslabs/s3_vectors_mcp_server/consts.py
+++ b/src/s3-vectors-mcp/awslabs/s3_vectors_mcp_server/consts.py
@@ -1,0 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Constants for the S3 Vectors MCP server."""
+
+DEFAULT_REGION = "us-east-1"

--- a/src/s3-vectors-mcp/awslabs/s3_vectors_mcp_server/models.py
+++ b/src/s3-vectors-mcp/awslabs/s3_vectors_mcp_server/models.py
@@ -1,0 +1,131 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pydantic models for the S3 Vectors MCP server."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class Pagination(BaseModel):
+    """Pagination token container."""
+
+    next_token: Optional[str] = Field(default=None, alias="nextToken")
+
+
+class VectorBucket(BaseModel):
+    """Vector bucket metadata."""
+
+    name: str = Field(..., alias="name")
+
+
+class ListVectorBucketsResponse(BaseModel):
+    """Response model for list_vector_buckets."""
+
+    buckets: List[VectorBucket] = Field(default_factory=list, alias="buckets")
+    next_token: Optional[str] = Field(default=None, alias="nextToken")
+
+
+class CreateVectorBucketRequest(BaseModel):
+    """Request model for create_vector_bucket."""
+
+    bucket_name: str = Field(..., alias="bucketName")
+    kms_key_id: Optional[str] = Field(default=None, alias="kmsKeyId")
+
+
+class GetVectorBucketRequest(BaseModel):
+    """Request model for get_vector_bucket."""
+
+    bucket_name: str = Field(..., alias="bucketName")
+
+
+class ListIndexesRequest(BaseModel):
+    """Request model for list_indexes."""
+
+    bucket_name: str = Field(..., alias="bucketName")
+    next_token: Optional[str] = Field(default=None, alias="nextToken")
+
+
+class CreateIndexRequest(BaseModel):
+    """Request model for create_index."""
+
+    bucket_name: str = Field(..., alias="bucketName")
+    index_name: str = Field(..., alias="indexName")
+    dimensions: int = Field(..., alias="dimensions")
+    similarity: str = Field(default="COSINE", alias="similarity")
+    filterable_metadata: Optional[List[str]] = Field(default=None, alias="filterableMetadata")
+
+
+class GetIndexRequest(BaseModel):
+    """Request model for get_index."""
+
+    bucket_name: str = Field(..., alias="bucketName")
+    index_name: str = Field(..., alias="indexName")
+
+
+class ListVectorsRequest(BaseModel):
+    """Request model for list_vectors."""
+
+    bucket_name: str = Field(..., alias="bucketName")
+    index_name: str = Field(..., alias="indexName")
+    include_data: bool = Field(default=False, alias="includeData")
+    include_metadata: bool = Field(default=False, alias="includeMetadata")
+    next_token: Optional[str] = Field(default=None, alias="nextToken")
+
+
+class EmbedAndStoreTextRequest(BaseModel):
+    """Request model for embed_and_store_text."""
+
+    bucket_name: str = Field(..., alias="bucketName")
+    index_name: str = Field(..., alias="indexName")
+    text: str
+    metadata: Optional[Dict[str, str]] = None
+
+
+class EmbedAndStoreFileRequest(BaseModel):
+    """Request model for embed_and_store_file."""
+
+    bucket_name: str = Field(..., alias="bucketName")
+    index_name: str = Field(..., alias="indexName")
+    file_path: str = Field(..., alias="filePath")
+    metadata: Optional[Dict[str, str]] = None
+
+
+class EmbedAndStoreS3ObjectsRequest(BaseModel):
+    """Request model for embed_and_store_s3_objects."""
+
+    bucket_name: str = Field(..., alias="bucketName")
+    index_name: str = Field(..., alias="indexName")
+    s3_uri_prefix: str = Field(..., alias="s3UriPrefix")
+    metadata: Optional[Dict[str, str]] = None
+
+
+class EmbedAndQueryTextRequest(BaseModel):
+    """Request model for embed_and_query_text."""
+
+    bucket_name: str = Field(..., alias="bucketName")
+    index_name: str = Field(..., alias="indexName")
+    text: str
+    top_k: int = Field(default=5, alias="topK")
+
+
+class EmbedAndQueryFileRequest(BaseModel):
+    """Request model for embed_and_query_file."""
+
+    bucket_name: str = Field(..., alias="bucketName")
+    index_name: str = Field(..., alias="indexName")
+    file_path: str = Field(..., alias="filePath")
+    top_k: int = Field(default=5, alias="topK")

--- a/src/s3-vectors-mcp/awslabs/s3_vectors_mcp_server/server.py
+++ b/src/s3-vectors-mcp/awslabs/s3_vectors_mcp_server/server.py
@@ -1,0 +1,237 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""MCP server exposing AWS S3 Vectors tools."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Dict, Optional
+
+try:
+    from mcp.server.fastmcp import FastMCP, Context
+except Exception:  # pragma: no cover - optional dependency
+    class _StubMCP:
+        """Fallback MCP class when fastmcp is unavailable."""
+
+        def tool(self, *_args: Any, **_kwargs: Any):  # noqa: D401 - simple passthrough
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def run(self) -> None:  # pragma: no cover - runtime only
+            raise RuntimeError("fastmcp is required to run the server")
+
+    FastMCP = _StubMCP  # type: ignore[assignment]
+    Context = Any  # type: ignore[assignment]
+
+from .consts import DEFAULT_REGION
+from . import __version__
+
+INSTRUCTIONS = """Interact with the AWS S3 Vectors service."""
+
+mcp = FastMCP("awslabs-s3-vectors-mcp-server", instructions=INSTRUCTIONS)
+
+
+def _client(region: Optional[str] = None):
+    """Return an S3 Vectors boto3 client."""
+    boto3 = importlib.import_module("boto3")  # type: ignore[import]
+    return boto3.client("s3vectors", region_name=region or DEFAULT_REGION)
+
+
+@mcp.tool()
+def list_vector_buckets(ctx: Context, next_token: Optional[str] = None) -> Dict[str, Any]:
+    """List vector buckets with optional pagination."""
+    client = _client()
+    params: Dict[str, Any] = {}
+    if next_token:
+        params["nextToken"] = next_token
+    return client.list_vector_buckets(**params)
+
+
+@mcp.tool()
+def create_vector_bucket(ctx: Context, bucket_name: str, kms_key_id: Optional[str] = None) -> Dict[str, Any]:
+    """Create a new vector bucket."""
+    client = _client()
+    params: Dict[str, Any] = {"bucketName": bucket_name}
+    if kms_key_id:
+        params["kmsKeyId"] = kms_key_id
+    return client.create_vector_bucket(**params)
+
+
+@mcp.tool()
+def get_vector_bucket(ctx: Context, bucket_name: str) -> Dict[str, Any]:
+    """Retrieve vector bucket metadata."""
+    client = _client()
+    return client.get_vector_bucket(bucketName=bucket_name)
+
+
+@mcp.tool()
+def list_indexes(ctx: Context, bucket_name: str, next_token: Optional[str] = None) -> Dict[str, Any]:
+    """List indexes for a given bucket."""
+    client = _client()
+    params: Dict[str, Any] = {"bucketName": bucket_name}
+    if next_token:
+        params["nextToken"] = next_token
+    return client.list_indexes(**params)
+
+
+@mcp.tool()
+def create_index(
+    ctx: Context,
+    bucket_name: str,
+    index_name: str,
+    dimensions: int,
+    similarity: str = "COSINE",
+    filterable_metadata: Optional[list[str]] = None,
+) -> Dict[str, Any]:
+    """Create a vector index in a bucket."""
+    client = _client()
+    params: Dict[str, Any] = {
+        "bucketName": bucket_name,
+        "indexName": index_name,
+        "dimensions": dimensions,
+        "similarity": similarity,
+    }
+    if filterable_metadata:
+        params["filterableMetadata"] = filterable_metadata
+    return client.create_index(**params)
+
+
+@mcp.tool()
+def get_index(ctx: Context, bucket_name: str, index_name: str) -> Dict[str, Any]:
+    """Get index configuration and statistics."""
+    client = _client()
+    return client.get_index(bucketName=bucket_name, indexName=index_name)
+
+
+@mcp.tool()
+def list_vectors(
+    ctx: Context,
+    bucket_name: str,
+    index_name: str,
+    include_data: bool = False,
+    include_metadata: bool = False,
+    next_token: Optional[str] = None,
+) -> Dict[str, Any]:
+    """List vectors stored in an index."""
+    client = _client()
+    params: Dict[str, Any] = {
+        "bucketName": bucket_name,
+        "indexName": index_name,
+        "includeData": include_data,
+        "includeMetadata": include_metadata,
+    }
+    if next_token:
+        params["nextToken"] = next_token
+    return client.list_vectors(**params)
+
+
+@mcp.tool()
+def embed_and_store_text(
+    ctx: Context,
+    bucket_name: str,
+    index_name: str,
+    text: str,
+    metadata: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    """Generate embeddings from text and store them in an index."""
+    client = _client()
+    params: Dict[str, Any] = {
+        "bucketName": bucket_name,
+        "indexName": index_name,
+        "text": text,
+    }
+    if metadata:
+        params["metadata"] = metadata
+    return client.embed_and_store_text(**params)
+
+
+@mcp.tool()
+def embed_and_store_file(
+    ctx: Context,
+    bucket_name: str,
+    index_name: str,
+    file_path: str,
+    metadata: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    """Embed a local file and store the vector."""
+    client = _client()
+    params: Dict[str, Any] = {
+        "bucketName": bucket_name,
+        "indexName": index_name,
+        "filePath": file_path,
+    }
+    if metadata:
+        params["metadata"] = metadata
+    return client.embed_and_store_file(**params)
+
+
+@mcp.tool()
+def embed_and_store_s3_objects(
+    ctx: Context,
+    bucket_name: str,
+    index_name: str,
+    s3_uri_prefix: str,
+    metadata: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    """Embed S3 objects and store vectors in batch."""
+    client = _client()
+    params: Dict[str, Any] = {
+        "bucketName": bucket_name,
+        "indexName": index_name,
+        "s3UriPrefix": s3_uri_prefix,
+    }
+    if metadata:
+        params["metadata"] = metadata
+    return client.embed_and_store_s3_objects(**params)
+
+
+@mcp.tool()
+def embed_and_query_text(
+    ctx: Context,
+    bucket_name: str,
+    index_name: str,
+    text: str,
+    top_k: int = 5,
+) -> Dict[str, Any]:
+    """Query an index using natural language text."""
+    client = _client()
+    return client.embed_and_query_text(
+        bucketName=bucket_name, indexName=index_name, text=text, topK=top_k
+    )
+
+
+@mcp.tool()
+def embed_and_query_file(
+    ctx: Context,
+    bucket_name: str,
+    index_name: str,
+    file_path: str,
+    top_k: int = 5,
+) -> Dict[str, Any]:
+    """Query an index using a file's content."""
+    client = _client()
+    return client.embed_and_query_file(
+        bucketName=bucket_name, indexName=index_name, filePath=file_path, topK=top_k
+    )
+
+
+def main() -> None:  # pragma: no cover - CLI entry point
+    """Run the MCP server."""
+    mcp.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/src/s3-vectors-mcp/pyproject.toml
+++ b/src/s3-vectors-mcp/pyproject.toml
@@ -1,0 +1,38 @@
+[project]
+name = "awslabs.s3-vectors-mcp-server"
+version = "0.1.0"
+description = "A Model Context Protocol server for AWS S3 Vectors"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{name = "Amazon Web Services"}]
+license = { text = "Apache-2.0" }
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+]
+dependencies = [
+    "mcp[cli]>=1.11.0",
+    "pydantic>=2.10.6",
+    "boto3>=1.34.0",
+]
+
+[project.scripts]
+"awslabs.s3-vectors-mcp-server" = "awslabs.s3_vectors_mcp_server.server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.0.0"
+tag_format = "v$version"
+version_files = [
+  "pyproject.toml:version",
+  "awslabs/s3_vectors_mcp_server/__init__.py:__version__"
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=awslabs.s3_vectors_mcp_server --cov-report=term-missing"

--- a/src/s3-vectors-mcp/tests/test_server.py
+++ b/src/s3-vectors-mcp/tests/test_server.py
@@ -1,0 +1,33 @@
+import ast
+from pathlib import Path
+
+
+def test_all_tools_defined():
+    server_path = Path(__file__).resolve().parents[1] / 'awslabs' / 's3_vectors_mcp_server' / 'server.py'
+    source = server_path.read_text()
+    tree = ast.parse(source)
+    tools = []
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef):
+            for dec in node.decorator_list:
+                if (
+                    isinstance(dec, ast.Call)
+                    and isinstance(dec.func, ast.Attribute)
+                    and dec.func.attr == 'tool'
+                ):
+                    tools.append(node.name)
+    expected = {
+        'list_vector_buckets',
+        'create_vector_bucket',
+        'get_vector_bucket',
+        'list_indexes',
+        'create_index',
+        'get_index',
+        'list_vectors',
+        'embed_and_store_text',
+        'embed_and_store_file',
+        'embed_and_store_s3_objects',
+        'embed_and_query_text',
+        'embed_and_query_file',
+    }
+    assert expected.issubset(set(tools)), tools


### PR DESCRIPTION
## Summary
- add initial AWS S3 Vectors MCP server with bucket, index, vector, and query tools
- include Pydantic models and FastMCP scaffolding
- add tests validating tool definitions

## Testing
- `pytest src/s3-vectors-mcp/tests/test_server.py -q -o addopts=""`
- `pre-commit run --files src/s3-vectors-mcp/awslabs/s3_vectors_mcp_server/server.py src/s3-vectors-mcp/awslabs/s3_vectors_mcp_server/models.py src/s3-vectors-mcp/awslabs/s3_vectors_mcp_server/consts.py src/s3-vectors-mcp/awslabs/__init__.py src/s3-vectors-mcp/awslabs/s3_vectors_mcp_server/__init__.py src/s3-vectors-mcp/tests/test_server.py src/s3-vectors-mcp/pyproject.toml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a6408dac83309ef03c1216908aaa